### PR TITLE
task-7 authorization

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -9,6 +9,13 @@ import PageProducts from "~/components/pages/PageProducts/PageProducts";
 import { Typography } from "@mui/material";
 
 function App() {
+  const userData = {
+    user: "dzevakov",
+    pw: "TEST_PASSWORD",
+  };
+
+  localStorage.setItem("auth", JSON.stringify(userData));
+
   return (
     <MainLayout>
       <Routes>

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import axios from "axios";
+import { Buffer } from "buffer";
 
 type CSVFileImportProps = {
   url: string;
@@ -23,14 +24,35 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
     setFile(undefined);
   };
 
+  const encodeUserData = (data: string | null) => {
+    if (data) {
+      const userData = JSON.parse(data);
+
+      const encodedAuthData = Buffer.from(
+        `${userData?.user}:${userData?.pw}`
+      ).toString("base64");
+
+      return {
+        authorization: `Basic ${encodedAuthData}`,
+      };
+    }
+
+    return undefined;
+  };
+
   const uploadFile = async () => {
     if (file?.name) {
       console.log("uploadFile to", url);
+
+      const userData = localStorage.getItem("auth");
+
+      const encodedAuthData = encodeUserData(userData);
 
       // Get the presigned URL
       const response = await axios({
         method: "GET",
         url,
+        headers: encodedAuthData,
         params: {
           name: encodeURIComponent(file.name),
         },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
+import axios from "axios";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,6 +19,21 @@ if (import.meta.env.DEV) {
   const { worker } = await import("./mocks/browser");
   worker.start({ onUnhandledRequest: "bypass" });
 }
+
+// Add a response interceptor
+axios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    if (error.response.status === 401) {
+      alert(`User is ${error.response.data.message.toLowerCase()}`);
+    } else if (error.response.status === 403) {
+      alert(`Access is ${error.response.data.message.toLowerCase()}`);
+    }
+    return Promise.reject(error);
+  }
+);
 
 const container = document.getElementById("app");
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
## Task 7.3

- Request from the client application to the /import path of the Import Service have Basic Authorization header, authorization_token} is a base64-encoded `dzevakov:TEST_PASSWORD`
- Client get authorization_token value from browser [localStorage]

## Additional (optional) tasks
- Client application display alerts for the responses in 401 and 403 HTTP statuses. This behavior was added to `/src/index.tsx` file.

## CloudFront link
[https://dgod361p6oftm.cloudfront.net/](https://dgod361p6oftm.cloudfront.net/)

![image](https://user-images.githubusercontent.com/68353420/236040894-15db4434-39c8-45dd-a97e-6a0099fff54a.png)

![image](https://user-images.githubusercontent.com/68353420/236040977-fc15dcd6-6fe1-4c48-b38c-5e9e622b0b0e.png)
